### PR TITLE
Upgrade to Laravel 13.7 (composer-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/composer.lock
+.phpunit.result.cache
+.phpunit.cache/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # df-mqtt
 
 df-mqtt is an MQTT client for DreamFactory, allowing DreamFactory to interact with MQTT-based message brokers.
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,18 @@
     }
   ],
   "require":     {
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4",
     "dreamfactory/df-pubsub": "~0.2",
-    "php-mqtt/client": "^1.7"
+    "php-mqtt/client": "^1.7 || ^2.1"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {


### PR DESCRIPTION
## Summary
- Composer-only upgrade of df-mqtt to Laravel 13.7. No source changes were needed.
- The package's only Illuminate import is `Illuminate\Support\Arr` (unchanged in L13). It contains no `DispatchesJobs` / `dispatchNow` / `getDates` / `CorsService` / `Connection`-`Grammar` overrides / `setupBeforeClass` typos / `getDoctrineDriver` calls — none of the 27 L13 invariants apply.
- `php-mqtt/client` widened from `^1.7` to `^1.7 || ^2.1`. v2's public surface (`MqttClient`, `ConnectionSettings`, `connect`, `publish`, `subscribe`, `loop`, `loopOnce`, `registerPublishEventHandler`, `registerMessageReceivedEventHandler`, `disconnect`) matches what `Components/MosquittoClient.php` uses; the optional `^2.1` track lets the host pick a current release on PHP 8.3.
- `laravel/helpers ^1.8` added to production `require` (polyfills `array_get`/`camel_case`/`array_except` for downstream code).
- Standard L13 `require-dev` block: `laravel/framework ^13.7`, `phpunit/phpunit ^11.5.3`, `orchestra/testbench ^11.0`, `mockery/mockery ^1.6`, `nunomaduro/collision ^8.6`.
- `.gitignore` added for `vendor/`, `composer.lock`, PHPUnit caches.

## Dependencies
- Requires `dreamfactory/df-core` `~1.0.4` on `shift/laravel-13`.
- Requires `dreamfactory/df-pubsub` `~0.2` — also being upgraded on its own `shift/laravel-13` branch (parallel Wave-3 work). df-pubsub is also composer-only.
- The Laravel `^13.7` host (shift-173254) installs both packages cleanly via path-repos.

## Test plan
- [x] `composer validate --strict --no-check-publish` passes.
- [x] Stage 1 isolated install in container with path-repos for df-core / df-system / df-user / df-pubsub (all on `shift/laravel-13`) resolves and installs Laravel 13.7.0 + PHPUnit 11.5.55 + php-mqtt/client v2.3.2 + orchestra/testbench v11.1.0.
- [x] `php -l` clean on all 8 source files.
- [x] All 8 namespaced classes (`ServiceProvider`, `Services\MQTT`, `Resources\Sub`, `Resources\Pub`, `Models\MQTTConfig`, `Components\MosquittoClient`, `Jobs\Subscribe`, `Exceptions\LoopException`) autoload under L13.
- [x] Stage 2 host-app smoke (shift-173254 with the standard scrub-list — `df-mongo-logs`, `df-git`, `df-oauth`, `df-mcp-server` removed, MongoDB ServiceProvider commented in `config/app.php`) installs df-mqtt 0.6.99 alongside Laravel 13.7.0 and surfaces all df-mqtt + df-pubsub classes plus the `laravel/helpers` polyfills (`array_get`, `camel_case`, `array_except`).
- [ ] End-to-end MQTT publish/subscribe against a Mosquitto broker — deferred until the rest of the Wave 3 stack lands and the host app boots.